### PR TITLE
Build separate slurm-wlm-nvml-plugin from Ubuntu 22.04+ sources

### DIFF
--- a/.github/workflows/slurmd-build-release.yml
+++ b/.github/workflows/slurmd-build-release.yml
@@ -67,10 +67,10 @@ jobs:
           done
           sudo apt-get update
 
-      - name: Install the Ubuntu build dependencies
+      - name: Install the Ubuntu build tools
         run: |
-          sudo apt-get -y build-dep --only-source "${SLURM_SRC_PKG}=${SLURM_VERSION}"
-          sudo apt-get -y install --no-install-recommends devscripts
+          sudo apt-get -y install --no-install-recommends \
+            devscripts equivs
 
       - name: Install the NVIDIA build dependencies
         run: |
@@ -79,11 +79,23 @@ jobs:
       - name: Prepare the build directory
         run: mkdir "${BUILDDIR}"
 
-      - name: Build the package
+      - name: Download the build sources
         working-directory: ${{ env.BUILDDIR }}
         run: |
           sudo apt-get source --only-source "${SLURM_SRC_PKG}=${SLURM_VERSION}"
-          cd "$(find -mindepth 1 -maxdepth 1 -type d -print -quit)"
+
+      - name: Install the build dependencies
+        working-directory: ${{ env.BUILDDIR }}
+        run: |
+          cd "${SLURM_SRC_PKG}-"*
+          mk-build-deps \
+            -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' \
+            -i debian/control
+
+      - name: Build the package
+        working-directory: ${{ env.BUILDDIR }}
+        run: |
+          cd "${SLURM_SRC_PKG}-"*
           debuild -us -uc -b
 
       - name: Verify that the nvml library was built

--- a/.github/workflows/slurmd-build-release.yml
+++ b/.github/workflows/slurmd-build-release.yml
@@ -28,14 +28,25 @@ jobs:
           echo "SLURM_VERSION=${SLURM_VERSION}" >> "${GITHUB_ENV}"
 
           # Pick the correct source package based on the version being built.
-          SLURM_MAJOR="$(echo "$SLURM_VERSION" | grep -Eo '^[0-9]+\.' | grep -Eo '[0-9]+')"
-          if [ "${SLURM_MAJOR}" == "19" ]; then
-            SLURM_SRC_PKG="slurm-llnl"
-            DEB_SOURCE_REPO="focal universe"
-          else
-            SLURM_SRC_PKG="slurm-wlm"
-            DEB_SOURCE_REPO="jammy universe"
-          fi
+          SLURM_SRC_PKG="slurm-wlm"
+          case "${SLURM_VERSION}" in
+            21.08.* )
+              DEB_SOURCE_REPO="jammy universe"
+              ;;
+            23.10.* )
+              DEB_SOURCE_REPO="mantic universe"
+              ;;
+            24.04.* )
+              DEB_SOURCE_REPO="noble universe"
+              ;;
+            24.10.* )
+              DEB_SOURCE_REPO="oracular universe"
+              ;;
+            * )
+              1>&2 echo "No deb source repo for Slurm version ${SLURM_VERSION}"
+              false
+              ;;
+          esac
           echo "SLURM_SRC_PKG=${SLURM_SRC_PKG}" >> "${GITHUB_ENV}"
           echo "DEB_SOURCE_REPO=${DEB_SOURCE_REPO}" >> "${GITHUB_ENV}"
 
@@ -44,7 +55,16 @@ jobs:
 
       - name: Enable the source repository
         run: |
-          echo "deb-src http://archive.ubuntu.com/ubuntu ${DEB_SOURCE_REPO}" | sudo tee -a /etc/apt/sources.list.d/debsrc.list
+          echo "deb-src http://archive.ubuntu.com/ubuntu/ ${DEB_SOURCE_REPO}" |
+            sudo tee -a /etc/apt/sources.list.d/debsrc.list
+          # Use old-releases.ubuntu.com for non-LTS EOL versions.
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/*; do
+            sed -Ei \
+              '/ubuntu\.com\/ubuntu\/ (kinetic|lunar|mantic)/ {
+                s|http://[^.]*|http://old-releases|
+              }' \
+              -- "${f}"
+          done
           sudo apt-get update
 
       - name: Install the Ubuntu build dependencies

--- a/.github/workflows/slurmd-build-release.yml
+++ b/.github/workflows/slurmd-build-release.yml
@@ -21,10 +21,6 @@ jobs:
     runs-on: ubuntu-${{ matrix.runner_version }}
     permissions:
       contents: write
-    env:
-      NVIDIA_DRIVER_VERSION: "535"
-      NVIDIA_CUDA_VERSION: "12-2"
-      CUDA_KEYRING_VERSION: "1.1-1"
     steps:
       - name: Prepare the environment
         run: |
@@ -58,15 +54,7 @@ jobs:
 
       - name: Install the NVIDIA build dependencies
         run: |
-          sudo apt-get -y install ca-certificates curl
-          source /etc/os-release
-          curl -LO "https://developer.download.nvidia.com/compute/cuda/repos/${ID}$(echo ${VERSION_ID} | tr -d ".")/x86_64/cuda-keyring_${CUDA_KEYRING_VERSION}_all.deb"
-          sudo dpkg -i "cuda-keyring_${CUDA_KEYRING_VERSION}_all.deb"
-          sudo ln -s "/usr/local/cuda-$(echo "${NVIDIA_CUDA_VERSION}" | tr "-" "." )" /usr/local/cuda
-          sudo apt-get update
-          sudo apt-get -y install \
-            "libnvidia-compute-${NVIDIA_DRIVER_VERSION}" \
-            "cuda-nvml-dev-${NVIDIA_CUDA_VERSION}"
+          sudo apt-get -y install libnvidia-ml-dev
 
       - name: Prepare the build directory
         run: mkdir "${BUILDDIR}"
@@ -96,10 +84,5 @@ jobs:
         with:
           body: |
             # Slurm ${{ env.SLURM_VERSION }} with gpu/nvml
-
-            Built with the following NVIDIA dependencies:
-
-            - libnvidia-compute-${{ env.NVIDIA_DRIVER_VERSION }}
-            - cuda-nvml-dev-${{ env.NVIDIA_CUDA_VERSION }}
           files: ${{ env.BUILDDIR }}.tar.gz
           fail_on_unmatched_files: true

--- a/.github/workflows/slurmd-build-release.yml
+++ b/.github/workflows/slurmd-build-release.yml
@@ -17,7 +17,7 @@ jobs:
   build-debs-and-release:
     strategy:
       matrix:
-        runner_version: ["20.04", "22.04"]
+        runner_version: ["22.04", "24.04"]
     runs-on: ubuntu-${{ matrix.runner_version }}
     permissions:
       contents: write

--- a/.github/workflows/slurmd-build-release.yml
+++ b/.github/workflows/slurmd-build-release.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           SLURM_VERSION="${{ github.ref_name }}"
           echo "SLURM_VERSION=${SLURM_VERSION}" >> "${GITHUB_ENV}"
+          UBUNTU_VERSION="${{ matrix.runner_version }}"
+          echo "UBUNTU_VERSION=${UBUNTU_VERSION}" >> "${GITHUB_ENV}"
 
           # Pick the correct source package based on the version being built.
           SLURM_SRC_PKG="slurm-wlm"
@@ -50,7 +52,26 @@ jobs:
           echo "SLURM_SRC_PKG=${SLURM_SRC_PKG}" >> "${GITHUB_ENV}"
           echo "DEB_SOURCE_REPO=${DEB_SOURCE_REPO}" >> "${GITHUB_ENV}"
 
-          BUILDDIR="${SLURM_SRC_PKG}-${SLURM_VERSION}-ubuntu${{ matrix.runner_version }}-debs"
+          # Patch the build files to build separate slurm-wlm-nvml-plugin
+          # package and be able to build on newer and/or older OS versions.
+          # These use sed etc. instead of actual .patch files since otherwise
+          # we'd need to maintain version-specific .patch files.
+          PATCHES_SH="$(pwd)/patches.sh"
+          >> "${PATCHES_SH}" echo '#! /bin/sh -xeu'
+          chmod +x -- "${PATCHES_SH}"
+          >> "${PATCHES_SH}" cat \
+            ./patches/add-slurm-wlm-nvml-plugin.sh \
+            ./patches/libslurm-slurm_strlcpy-only-ifndef-HAVE_STRLCPY.sh \
+            ./patches/drop-dpkg-dev-debhelper-min-version-constraints.sh
+          [ "${UBUNTU_VERSION%%.*}" -lt 23 ] &&
+            >> "${PATCHES_SH}" cat \
+              ./patches/remove-slurm-wlm-rsmi-plugin.sh
+          [ "${UBUNTU_VERSION%%.*}" -lt 21 ] &&
+            >> "${PATCHES_SH}" cat \
+              ./patches/revert-to-pmix-3-prefix.sh
+          echo "PATCHES_SH=${PATCHES_SH}" >> "${GITHUB_ENV}"
+
+          BUILDDIR="${SLURM_SRC_PKG}-${SLURM_VERSION}-ubuntu${UBUNTU_VERSION}-debs"
           echo "BUILDDIR=${BUILDDIR}" >> "${GITHUB_ENV}"
 
       - name: Enable the source repository
@@ -83,6 +104,8 @@ jobs:
         working-directory: ${{ env.BUILDDIR }}
         run: |
           sudo apt-get source --only-source "${SLURM_SRC_PKG}=${SLURM_VERSION}"
+          cd "${SLURM_SRC_PKG}-"*
+          "${PATCHES_SH}"
 
       - name: Install the build dependencies
         working-directory: ${{ env.BUILDDIR }}
@@ -100,7 +123,7 @@ jobs:
 
       - name: Verify that the nvml library was built
         working-directory: ${{ env.BUILDDIR }}
-        run: dpkg-deb -c slurm-wlm-basic-plugins_*_amd64.deb | grep gpu_nvml.so > /dev/null
+        run: dpkg-deb -c slurm-wlm-nvml-plugin_*_amd64.deb | grep -q gpu_nvml.so
 
       - name: Create the release archive
         run: |

--- a/patches/add-slurm-wlm-nvml-plugin.sh
+++ b/patches/add-slurm-wlm-nvml-plugin.sh
@@ -1,0 +1,53 @@
+# Add slurm-wlm-nvml-plugin
+#
+# Package definitions are from slurm-wlm-contrib.
+
+sed -i debian/control -e '
+/^Build-Depends:/ a\
+ libnvidia-ml-dev,
+
+$ a\
+\
+Package: slurm-wlm-nvml-plugin\
+Section: contrib/libs\
+Architecture: any\
+Depends:\
+ ${shlibs:Depends},\
+ ${misc:Depends},\
+ slurm-wlm-basic-plugins (= ${binary:Version})\
+Enhances: slurmd (= ${binary:Version})\
+Description: SLURM NVML plugins\
+ SLURM, the Simple Linux Utility for Resource Management,\
+ is an open-source cluster resource management and job scheduling.\
+ .\
+ This package contains the Nvidia NVML-based SLURM plugin.\
+\
+Package: slurm-wlm-nvml-plugin-dev\
+Section: contrib/devel\
+Architecture: any\
+Depends:\
+ ${shlibs:Depends},\
+ ${misc:Depends},\
+ slurm-wlm-basic-plugins-dev (= ${binary:Version}),\
+ slurm-wlm-nvml-plugin (= ${binary:Version}),\
+ libnvidia-ml-dev,\
+Description: SLURM NVML plugin development files\
+ SLURM, the Simple Linux Utility for Resource Management,\
+ is an open-source cluster resource management and job scheduling.\
+ .\
+ This package contains development files for the Nvidia NVML-based\
+ SLURM plugins.\
+'
+
+sed -i debian/rules -e '
+/^override_dh_strip:/ a\\tdh_strip -pslurm-wlm-nvml-plugin
+'
+
+cat > debian/slurm-wlm-nvml-plugin.install << 'EOF'
+usr/lib/*/slurm-wlm/gpu_nvml.so
+EOF
+
+cat > debian/slurm-wlm-nvml-plugin-dev.install << 'EOF'
+usr/lib/*/slurm-wlm/gpu_nvml.a
+usr/lib/*/slurm-wlm/gpu_nvml.la
+EOF

--- a/patches/drop-dpkg-dev-debhelper-min-version-constraints.sh
+++ b/patches/drop-dpkg-dev-debhelper-min-version-constraints.sh
@@ -1,0 +1,9 @@
+# Drop dpkg-dev, debhelper min version constraints
+#
+# We want to build on older Ubuntu versions that cannot satisfy these
+# constraints -- so, fingers crossed that nothing major requires them...
+
+sed -i debian/control -e '
+s/ dpkg-dev (>= [^)]*),/ dpkg-dev,/
+s/ debhelper (>= [^)]*),/ debhelper,/
+'

--- a/patches/libslurm-slurm_strlcpy-only-ifndef-HAVE_STRLCPY.sh
+++ b/patches/libslurm-slurm_strlcpy-only-ifndef-HAVE_STRLCPY.sh
@@ -1,0 +1,7 @@
+# slurm_strlcpy only only defined ifndef HAVE_STRLCPY
+#
+# Later versions have "(optional)" declaration already in place.
+
+sed -i debian/libslurm*.symbols -e '
+/^ slurm_strlcpy@Base 1.3.8/ s/^ / (optional)/
+'

--- a/patches/remove-slurm-wlm-rsmi-plugin.sh
+++ b/patches/remove-slurm-wlm-rsmi-plugin.sh
@@ -1,0 +1,15 @@
+# Remove slurm-wlm-rsmi-plugin
+#
+# Ubuntu <23.04 does not have librocm-smi-dev.
+
+sed -i debian/control -e '
+/^ librocm-smi-dev,\?/ d
+/^ slurm-wlm-rsmi-plugin.*,/ d
+/^Package: slurm-wlm-rsmi-plugin.*$/,/^$/ d
+'
+
+sed -i debian/rules -e '
+/dh_strip -pslurm-wlm-rsmi-plugin/d
+'
+
+rm -f debian/slurm-wlm-rsmi-plugin*

--- a/patches/revert-to-pmix-3-prefix.sh
+++ b/patches/revert-to-pmix-3-prefix.sh
@@ -1,0 +1,7 @@
+# Revert to PMIx 3 prefix
+#
+# libpmi paths in Ubuntu <21.04 have /usr/lib/*/pmix prefix.
+
+sed -i debian/rules -e '
+/--with-pmix=/ s|/pmix2|/pmix|g
+'


### PR DESCRIPTION
This separates out `slurm-wlm-nvml-plugin` into its own package as is also done in Debian/Ubuntu's `slurm-wlm-contrib` source package.
That way, we have packages matching upstream Ubuntu's more closely.

The actual workflow definition hasn't been tested yet but covers the steps that made it possible for me to locally built the `slurm-wlm`-based packages on Ubuntu 20.04 onward using the sources from Ubuntu 22.04 onward.
I.e., we should be able to build, e.g.

- https://blueprints.launchpad.net/ubuntu/+source/slurm-wlm/23.02.3-2ubuntu1
- https://blueprints.launchpad.net/ubuntu/+source/slurm-wlm/23.11.4-1.2ubuntu5

on Ubuntu 22.04 and 24.04.

EMCP-config needs to be adjusted to install `slurm-wlm-nvml-plugin` besides the existing `slurm-wlm-basic-plugins` package, of course.